### PR TITLE
Refactor/use vault id token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# gitlab-ci-catalog
+# Catalogue de pipelines Gitlab
+
+Ce dépôt à pour but de proposer des pipelines compatibles avec la plateforme Cloud π Native pour faciliter l'utilisation des services dépendants des CI/CD Gitlab.
+
+## Contributions
+
+Cf. [Conventions - MIOM Fabrique Numérique](https://docs.fabrique-numerique.fr/conventions/nommage.html).
+
+Les commits doivent suivre la spécification des [Commits Conventionnels](https://www.conventionalcommits.org/en/v1.0.0/), il est possible d'ajouter l'[extension VSCode](https://github.com/vivaxy/vscode-conventional-commits) pour faciliter la création des commits.
+
+Une PR doit être faite avec une branche à jour avec la branche `main` en rebase (et sans merge) avant demande de fusion, et la fusion doit être demandée dans `main`.

--- a/mirror.yml
+++ b/mirror.yml
@@ -1,11 +1,14 @@
 .repo_pull_sync:
   image: ghcr.io/cloud-pi-native/git-sync:latest
+  id_tokens:
+    VAULT_ID_TOKEN:
+      aud: $VAULT_SERVER_URL
   before_script:
     - export EXTRA_ARGS=""
     - if [ ! -z $http_proxy ]; then export BUILD_ARGS="$BUILD_ARGS --build-arg http_proxy=$http_proxy"; fi
   script:
     - export VAULT_ADDR=$VAULT_SERVER_URL
-    - export VAULT_TOKEN="$(vault write ${EXTRA_VAULT_ARGS} -field=token auth/jwt/login role=default-ci jwt=$CI_JOB_JWT)"
+    - export VAULT_TOKEN="$(vault write ${EXTRA_VAULT_ARGS} -field=token auth/jwt/login role=default-ci jwt=$VAULT_ID_TOKEN)"
     - export GIT_INPUT_USER=`vault kv get ${EXTRA_VAULT_ARGS} -field=GIT_INPUT_USER ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/${PROJECT_NAME}-mirror`
     - export GIT_INPUT_PASSWORD=`vault kv get ${EXTRA_VAULT_ARGS} -field=GIT_INPUT_PASSWORD ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/${PROJECT_NAME}-mirror`
     - export GIT_INPUT_URL=`vault kv get ${EXTRA_VAULT_ARGS} -field=GIT_INPUT_URL ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/${PROJECT_NAME}-mirror`

--- a/sonar-ci.yml
+++ b/sonar-ci.yml
@@ -6,7 +6,7 @@ variables:
 
 .sonar:sonar-scanner:
   image: 
-    name: sonarsource/sonar-scanner-cli:5.0.1
+    name: docker.io/sonarsource/sonar-scanner-cli:5.0.1
     entrypoint: [""]
   variables:
     SONAR_USER_HOME: "${CI_PROJECT_DIR}/.sonar"

--- a/vault-ci.yml
+++ b/vault-ci.yml
@@ -1,6 +1,6 @@
 .vault:read_secret:
   image:
-    name: docker.io/vault:1.13.3
+    name: docker.io/hashicorp/vault:1.17.1
   id_tokens:
     VAULT_ID_TOKEN:
       aud: $VAULT_SERVER_URL

--- a/vault-ci.yml
+++ b/vault-ci.yml
@@ -1,10 +1,13 @@
 .vault:read_secret:
   image:
     name: docker.io/vault:1.13.3
+  id_tokens:
+    VAULT_ID_TOKEN:
+      aud: $VAULT_SERVER_URL
   script:
     - export PROJECT_PATH=`echo "$CI_PROJECT_NAMESPACE" | awk -F '/' '{print $(NF - 1)"-"$(NF)}'`
     - export VAULT_ADDR=$VAULT_SERVER_URL
-    - export VAULT_TOKEN="$(vault write $EXTRA_VAULT_ARGS -field=token auth/jwt/login role=default-ci jwt=$CI_JOB_JWT)"
+    - export VAULT_TOKEN="$(vault write $EXTRA_VAULT_ARGS -field=token auth/jwt/login role=default-ci jwt=$VAULT_ID_TOKEN)"
     - export DOCKER_AUTH=`vault kv get $EXTRA_VAULT_ARGS -field=DOCKER_CONFIG ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/REGISTRY/rw-robot`
     - export REGISTRY_HOST=`vault kv get $EXTRA_VAULT_ARGS -field=HOST ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/REGISTRY/rw-robot`
     - export SONAR_TOKEN=`vault kv get $EXTRA_VAULT_ARGS -field=SONAR_TOKEN ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/SONAR`


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Actuellement Gitlab utilise le token `CI_JOB_JWT` pour récupérer les secrets dans Vault, ce qui n'est plus possible en `v17` de Gitlab.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Gitlab utilise désormais le token `VAULT_ID_TOKEN`.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Ajout de documentation dans le readme.

Cf. doc Gitlab :
- https://docs.gitlab.com/ee/ci/secrets/id_token_authentication.html#automatic-id-token-authentication-with-hashicorp-vault
- https://docs.gitlab.com/ee/ci/secrets/convert-to-id-tokens.html#kv-secrets-engine-v2
- https://docs.gitlab.com/ee/ci/examples/authenticating-with-hashicorp-vault/
