### PR TITLE
fix(kaniko): use dockerfile in context directory ; enable to customize both

### DIFF
--- a/kaniko-ci.yml
+++ b/kaniko-ci.yml
@@ -40,5 +40,8 @@
     - if [ ! -z $CA_BUNDLE ]; then cat $CA_BUNDLE >> /kaniko/ssl/certs/additional-ca-cert-bundle.crt; fi
     - mkdir -p /kaniko/.docker
     - echo "$DOCKER_AUTH" > /kaniko/.docker/config.json
-    - /kaniko/executor --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy --build-arg no_proxy=$no_proxy $EXTRA_BUILD_ARGS --context="$CI_PROJECT_DIR" --dockerfile="$CI_PROJECT_DIR/$WORKING_DIR/$DOCKERFILE" --destination $REGISTRY_URL/$IMAGE_NAME:$TAG
+    - /kaniko/executor --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy --build-arg no_proxy=$no_proxy $EXTRA_BUILD_ARGS 
+      --context="$CI_PROJECT_DIR"
+      --dockerfile="$CI_PROJECT_DIR/$WORKING_DIR/$DOCKERFILE"
+      --destination $REGISTRY_URL/$IMAGE_NAME:$TAG
     

--- a/kaniko-ci.yml
+++ b/kaniko-ci.yml
@@ -22,7 +22,7 @@
     - echo "$DOCKER_AUTH" > /kaniko/.docker/config.json
     - /kaniko/executor 
       --context="$CI_PROJECT_DIR/$WORKING_DIR" 
-      --dockerfile="$CI_PROJECT_DIR/$DOCKERFILE" 
+      --dockerfile="$CI_PROJECT_DIR/$WORKING_DIR/$DOCKERFILE" 
       $BUILD_ARGS $EXTRA_BUILD_ARGS $EXTRA_KANIKO_ARGS
       $ALL_DESTINATIONS
 
@@ -41,7 +41,7 @@
     - mkdir -p /kaniko/.docker
     - echo "$DOCKER_AUTH" > /kaniko/.docker/config.json
     - /kaniko/executor --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy --build-arg no_proxy=$no_proxy $EXTRA_BUILD_ARGS 
-      --context="$CI_PROJECT_DIR"
+      --context="$CI_PROJECT_DIR/$WORKING_DIR"
       --dockerfile="$CI_PROJECT_DIR/$WORKING_DIR/$DOCKERFILE"
       --destination $REGISTRY_URL/$IMAGE_NAME:$TAG
     


### PR DESCRIPTION
## Issues liées

- harmonise l'impact des variables `$WORKING_DIR` et  `$DOCKERFILE` sur le contexte docker et l'emplacement du dockerfile
- permet de gérer les monorepos, avec notamment le cas suivant : 
  - context: `./packages/backend`
  - dockerfile:  `./packages/backend/Dockerfile`

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?

Actuellement les actions du catalogue kaniko ne permettent pas de résoudre le cas évoqué.

## Quel est le nouveau comportement ?

Voir cas évoqué

## Cette PR introduit-elle un breaking change ?

Oui. Dans les cas où le Dockerfile n'est pas dans le dossier du contexte docker build.


