### PR TITLE
feat :sparkles: add vault certificat

### DIFF
--- a/vault-ci.yml
+++ b/vault-ci.yml
@@ -5,6 +5,11 @@
     VAULT_ID_TOKEN:
       aud: $VAULT_SERVER_URL
   script:
+    # CA
+    - if [ ! -z $CA_BUNDLE ]; then
+        cat $CA_BUNDLE >> /tmp/additional-ca-cert-bundle.pem;
+        export VAULT_CACERT=/tmp/additional-ca-cert-bundle.pem;
+      fi
     - export PROJECT_PATH=`echo "$CI_PROJECT_NAMESPACE" | awk -F '/' '{print $(NF - 1)"-"$(NF)}'`
     - export VAULT_ADDR=$VAULT_SERVER_URL
     - export VAULT_TOKEN="$(vault write $EXTRA_VAULT_ARGS -field=token auth/jwt/login role=default-ci jwt=$VAULT_ID_TOKEN)"

--- a/vault-ci.yml
+++ b/vault-ci.yml
@@ -7,8 +7,7 @@
   script:
     # CA
     - if [ ! -z $CA_BUNDLE ]; then
-        cat $CA_BUNDLE >> /tmp/additional-ca-cert-bundle.pem;
-        export VAULT_CACERT=/tmp/additional-ca-cert-bundle.pem;
+        export VAULT_CACERT=$CA_BUNDLE;
       fi
     - export PROJECT_PATH=`echo "$CI_PROJECT_NAMESPACE" | awk -F '/' '{print $(NF - 1)"-"$(NF)}'`
     - export VAULT_ADDR=$VAULT_SERVER_URL


### PR DESCRIPTION
## Quel est le comportement actuel ?
Lorsque le certificat est auto-signé le commande `vault` peut échouer avec l'erreur suivante  : **x509: certificate signed by unknown authority**

## Quel est le nouveau comportement ?
Utilisation de la variable CA_BUNDLE si présente pour définir la variable VAULT_CACERT


## Cette PR introduit-elle un breaking change ?
non

## Autres informations

![capture-catalog](https://github.com/user-attachments/assets/2596e3e9-f3ee-4fc8-b469-138bf8e45807)
