### PR TITLE
Ajout de la variable DOCKER_TOKEN

### DIFF
--- a/vault-ci.yml
+++ b/vault-ci.yml
@@ -13,6 +13,7 @@
     - export VAULT_ADDR=$VAULT_SERVER_URL
     - export VAULT_TOKEN="$(vault write $EXTRA_VAULT_ARGS -field=token auth/jwt/login role=default-ci jwt=$VAULT_ID_TOKEN)"
     - export DOCKER_AUTH=`vault kv get $EXTRA_VAULT_ARGS -field=DOCKER_CONFIG ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/REGISTRY/rw-robot`
+    - export DOCKER_TOKEN=`vault kv get $EXTRA_VAULT_ARGS -field=TOKEN ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/REGISTRY/rw-robot`
     - export REGISTRY_HOST=`vault kv get $EXTRA_VAULT_ARGS -field=HOST ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/REGISTRY/rw-robot`
     - export SONAR_TOKEN=`vault kv get $EXTRA_VAULT_ARGS -field=SONAR_TOKEN ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/SONAR`
     - export NEXUS_USERNAME=`vault kv get $EXTRA_VAULT_ARGS -field=NEXUS_USERNAME ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/NEXUS`


### PR DESCRIPTION
## Quel est le comportement actuel ?
Actuellement la construction d'images par Kaniko utilise DOCKER_AUTH (docker config) pour pousser dans le registre Harbor.

## Quel est le nouveau comportement ?
Certains autres outils, comme par exemple le spring-boot-maven-plugin, utilisent l'authentification par token, cf. https://docs.spring.io/spring-boot/maven-plugin/build-image.html#build-image.examples.docker.auth
La nouvelle variable DOCKER_TOKEN pourra être utilisée dans l'exemple ci-dessus pour valoriser docker.publishRegistry.token avec ${DOCKER_TOKEN}

## Cette PR introduit-elle un breaking change ?
Non
