### PR TITLE
feat: :sparkles: reduce the number of kaniko snapshot to 1

### DIFF
--- a/kaniko-ci.yml
+++ b/kaniko-ci.yml
@@ -37,6 +37,7 @@
     - mkdir -p /kaniko/.docker
     - echo "$DOCKER_AUTH" > /kaniko/.docker/config.json
     - /kaniko/executor 
+      --single-snapshot
       --context="$CI_PROJECT_DIR/$WORKING_DIR" 
       --dockerfile="$CI_PROJECT_DIR/$DOCKERFILE" 
       $BUILD_ARGS $EXTRA_BUILD_ARGS $EXTRA_KANIKO_ARGS
@@ -56,5 +57,12 @@
     - if [ ! -z $CA_BUNDLE ]; then cat $CA_BUNDLE >> /kaniko/ssl/certs/additional-ca-cert-bundle.crt; fi
     - mkdir -p /kaniko/.docker
     - echo "$DOCKER_AUTH" > /kaniko/.docker/config.json
-    - /kaniko/executor --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy --build-arg no_proxy=$no_proxy $EXTRA_BUILD_ARGS --context="$CI_PROJECT_DIR" --dockerfile="$CI_PROJECT_DIR/$WORKING_DIR/$DOCKERFILE" --destination $REGISTRY_URL/$IMAGE_NAME:$TAG
-    
+    - /kaniko/executor
+      --single-snapshot
+      --build-arg http_proxy=$http_proxy
+      --build-arg https_proxy=$https_proxy
+      --build-arg no_proxy=$no_proxy
+      --context="$CI_PROJECT_DIR"
+      --dockerfile="$CI_PROJECT_DIR/$WORKING_DIR/$DOCKERFILE"
+      --destination $REGISTRY_URL/$IMAGE_NAME:$TAG
+      $EXTRA_BUILD_ARGS $EXTRA_KANIKO_ARGS


### PR DESCRIPTION
## Issues liées

Issues numéro: https://github.com/cloud-pi-native/socle/issues/533

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
The below is happening several time in a same job.
```
INFO[0005] Initializing snapshotter ...                 
INFO[0005] Taking snapshot of full filesystem...
```

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Make it so the above could only trigger once per job.   
Should speed up the pipelines and reduce resource usage.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
No.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Thanks @Baboulinet-33 for the idea.