### PR TITLE
chore(#30): :arrow_up: use chainguard kaniko image

### DIFF
--- a/kaniko-ci.yml
+++ b/kaniko-ci.yml
@@ -5,7 +5,7 @@
     IMAGE_NAMES: $CI_PROJECT_NAME:$CI_COMMIT_BRANCH $CI_PROJECT_NAME:$CI_COMMIT_SHORT_SHA $CI_PROJECT_NAME:latest
     EXTRA_BUILD_ARGS: ""
   image:
-    name: gcr.io/kaniko-project/executor:debug
+    name: ghcr.io/kaniko-build/dist/chainguard-dev-kaniko/executor:v1.25.1-debug
     entrypoint: [""]
   script:
     # CA
@@ -50,7 +50,7 @@
     IMAGE_NAME: $IMAGE_NAMES
     EXTRA_BUILD_ARGS: ""
   image:
-    name: gcr.io/kaniko-project/executor:debug
+    name: ghcr.io/kaniko-build/dist/chainguard-dev-kaniko/executor:v1.25.1-debug
     entrypoint: [""]
   script:
     # CA


### PR DESCRIPTION
## Issues liées

Closes: #30 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Google stopped maintaining Kaniko (https://github.com/GoogleContainerTools/kaniko/issues/3348).
Chainguard is maintaining a fork with mostly dependencies update (https://github.com/chainguard-dev/kaniko?tab=readme-ov-file#history-and-status).
Images are build on https://github.com/kaniko-build/builder.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Use Chainguard Kaniko image for `kaniko-ci.yml`.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
No.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Other options would have been to migrate to buildah or buildkit. But this kind of engineering effort is not part of our year roadmap.