### PR TITLE
fix: add --skip-unused-stages to prevent unused stage to be built

### DIFF
--- a/kaniko-ci.yml
+++ b/kaniko-ci.yml
@@ -59,6 +59,7 @@
     - echo "$DOCKER_AUTH" > /kaniko/.docker/config.json
     - /kaniko/executor
       --single-snapshot
+      --skip-unused-stages
       --build-arg http_proxy=$http_proxy
       --build-arg https_proxy=$https_proxy
       --build-arg no_proxy=$no_proxy


### PR DESCRIPTION
## Issues liées

Issues numéro: #49 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?

Aujourd'hui, on multi-stage Kaniko non linéaire (exemple dans l'issue liée) construit tous les stages. On aimerait que les stages non utilisés soient ignorés pour diminuer les build-time.

## Quel est le nouveau comportement ?

Les stages inutiles ne sont pas construits.

## Cette PR introduit-elle un breaking change ?

Non
