### PR TITLE
Add registry mirror option to kaniko configuration

### DIFF
--- a/kaniko-ci.yml
+++ b/kaniko-ci.yml
@@ -40,6 +40,7 @@
       --single-snapshot
       --context="$CI_PROJECT_DIR/$WORKING_DIR" 
       --dockerfile="$CI_PROJECT_DIR/$DOCKERFILE" 
+      --registry-mirror="${REGISTRY_HOST}/dockerhub"
       $BUILD_ARGS $EXTRA_BUILD_ARGS $EXTRA_KANIKO_ARGS
       $ALL_DESTINATIONS
 
@@ -65,5 +66,6 @@
       --build-arg no_proxy=$no_proxy
       --context="$CI_PROJECT_DIR"
       --dockerfile="$CI_PROJECT_DIR/$WORKING_DIR/$DOCKERFILE"
+      --registry-mirror="${REGISTRY_HOST}/dockerhub"
       --destination $REGISTRY_URL/$IMAGE_NAME:$TAG
       $EXTRA_BUILD_ARGS $EXTRA_KANIKO_ARGS


### PR DESCRIPTION
Pour utiliser le proxy Harbor et éviter le rate limit dockerhub.

## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
Le build Kaniko utilise le registry par défaut (dockerhub) ce qui amène à des problèmes de rate limit dockerhub.

## Quel est le nouveau comportement ?
Le build Kaniko utilise automatiquement le projet "dockerhub" qui en est un mirroir.

## Cette PR introduit-elle un breaking change ?
Non, si ce n'est peut-être lorsqu'un `.gitlab-ci` spécifie un autre `--registry-mirror` (dans les `EXTRA_BUILD_ARGS`), mais en principe, plusieurs `--registry-mirror` sont autorisés, donc ça ne devrait pas avoir d'impact.

## Autres informations
Ci-dessous, une capture qui montre que la configuration `--registry-mirror=harbor.external.cpin.numerique-interieur.com/dockerhub` fonctionne (vs. une mauvaise configuration qui ne fonctionne pas)
<img width="1809" height="282" alt="image" src="https://github.com/user-attachments/assets/4897176b-43b4-454a-b9a6-7e77dc36ac8e" />
