### PR TITLE
Refactor : Surcharge des registries ghcr et docker et gestion conditionnelle de Nexus

### DIFF
--- a/.gitlab-ci-dso.example.java.yml
+++ b/.gitlab-ci-dso.example.java.yml
@@ -53,11 +53,11 @@ publish-npm-nexus:
   variables:
     BUILD_IMAGE_NAME: node:lts-bullseye
     WORKING_DIR: .
-    ARTEFACT_DIR: 'out/'
-    PRIVATE_GROUPS: ''
+    ARTEFACT_DIR: "out/"
+    PRIVATE_GROUPS: ""
     AUTODETECT_PRIVATE_GROUP: 1
   stage: build-app
-  extends: 
+  extends:
     - .npm:build-publish
 
 sonar-app:
@@ -71,7 +71,6 @@ sonar-app:
   stage: sonar
   extends:
     - .java:sonar
-
 
 # Docker build et push de l'image sur le repo Harbor
 docker-build:

--- a/.gitlab-ci-dso.example.java.yml
+++ b/.gitlab-ci-dso.example.java.yml
@@ -23,6 +23,7 @@ variables:
   TAG: "${CI_COMMIT_REF_SLUG}"
   DOCKERFILE: Dockerfile
   REGISTRY_URL: "${IMAGE_REPOSITORY}"
+  DOCKER_REGISTRY: docker.io
 
 # Differents stages du build. Le stage read-secret est obligatoire et permet de recuperer les secret CI du projet
 stages:
@@ -42,7 +43,7 @@ package-app:
     MAVEN_OPTS: "-Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository"
     MAVEN_CLI_OPTS: ""
     MVN_CONFIG_FILE: $MVN_CONFIG
-    BUILD_IMAGE_NAME: maven:3.8-openjdk-17
+    BUILD_IMAGE_NAME: $DOCKER_REGISTRY/maven:3.8-openjdk-17
     WORKING_DIR: .
     ARTEFACT_DIR: ./target/*.jar
   stage: build-app
@@ -51,7 +52,7 @@ package-app:
 
 publish-npm-nexus:
   variables:
-    BUILD_IMAGE_NAME: node:lts-bullseye
+    BUILD_IMAGE_NAME: $DOCKER_REGISTRY/node:lts-bullseye
     WORKING_DIR: .
     ARTEFACT_DIR: "out/"
     PRIVATE_GROUPS: ""
@@ -65,7 +66,7 @@ sonar-app:
     MAVEN_OPTS: "-Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository"
     MAVEN_CLI_OPTS: ""
     MVN_CONFIG_FILE: $MVN_CONFIG
-    BUILD_IMAGE_NAME: maven:3.8-openjdk-17
+    BUILD_IMAGE_NAME: $DOCKER_REGISTRY/maven:3.8-openjdk-17
     WORKING_DIR: .
     ARTEFACT_DIR: ./target/*.jar
   stage: sonar

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ Le build d'un artefact Java/Maven
 L'étape `build-java` permet de construire un artefact java (jar) via le gestionnaire de cycle de vie Maven et la commande `mvn clean package`.
 
 Il prend les paramètres suivants :
-  - `MAVEN\_OPTS` : `-Dmaven.repo.local=$CI\_PROJECT\_DIR/.m2/repository`. À positionner a minima à cette valeur
-  - `MAVEN\_CLI\_OPTS` : `""`. Options Maven supplémentaires ajoutées à `clean package`
-  - `MVN\_CONFIG\_FILE` : `$MVN\_CONFIG`.Fichier de configuration Maven, ici on utilise la variable `$MVN\_CONFIG` qui contient la configuration pour le projet.
-  - `BUILD\_IMAGE\_NAME` : `maven:3.8-openjdk-17`. Image utilisée pour construire l'artefact
-  - `WORKING\_DIR` : `.`. Répertoire de travail, la racine contenant le fichier pom.xml du projet
-  - `ARTEFACT\_DIR` : `./target/*.jar`. Répertoire contenant les artefacts générés par le build
+  - `MAVEN_OPTS` : `-Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository`. À positionner a minima à cette valeur
+  - `MAVEN_CLI_OPTS` : `""`. Options Maven supplémentaires ajoutées à `clean package`
+  - `MVN_CONFIG_FILE` : `$MVN_CONFIG`.Fichier de configuration Maven, ici on utilise la variable `$MVN_CONFIG` qui contient la configuration pour le projet.
+  - `BUILD_IMAGE_NAME` : `$DOCKER_REGISTRY/maven:3.8-openjdk-17`. Image utilisée pour construire l'artefact
+  - `WORKING_DIR` : `.`. Répertoire de travail, la racine contenant le fichier pom.xml du projet
+  - `ARTEFACT_DIR` : `./target/*.jar`. Répertoire contenant les artefacts générés par le build
 
  ### Sonar Java et Sonar Java JaCoCo
 
@@ -86,7 +86,7 @@ Paramètres :
   - `WORKING_DIR: .` : Répertoire de travail, contenant le fichier `package.json` du projet
   - `AUTODETECT_PRIVATE_GROUP: 1` : Mettre à `0` pour désactiver la détection automatique des paquets privés
   - `ARTEFACT_DIR: out` : Le dossier contenant les fichiers générés par votre build NPM
-  - `BUILD_IMAGE_NAME: node:lts-bullseye` : Image utilisée pour construire l'artefact
+  - `BUILD_IMAGE_NAME: $DOCKER_REGISTRY/node:lts-bullseye` : Image utilisée pour construire l'artefact
 
 ## Build docker
 

--- a/buildkit-ci.yml
+++ b/buildkit-ci.yml
@@ -1,3 +1,6 @@
+variables:
+  DOCKER_REGISTRY: docker.io
+
 .buildkit:build-push:
   variables:
     WORKING_DIR: "."
@@ -9,7 +12,7 @@
     EXTRA_BUILD_ARGS: ""
     EXTRA_BUILDKIT_ARGS: ""
   image:
-    name: moby/buildkit:rootless
+    name: $DOCKER_REGISTRY/moby/buildkit:rootless
     entrypoint: [""]
   script:
     # CA

--- a/helm-ci.yml
+++ b/helm-ci.yml
@@ -1,5 +1,8 @@
+variables:
+  DOCKER_REGISTRY: docker.io
+
 .helm:build-push:
-  image: alpine/helm:latest
+  image: $DOCKER_REGISTRY/alpine/helm:latest
   variables:
     CHARTS_DIR: ./charts
   script:

--- a/kaniko-ci.yml
+++ b/kaniko-ci.yml
@@ -1,3 +1,6 @@
+variables:
+  GHCR_REGISTRY: ghcr.io
+
 .kaniko:build-push:
   variables:
     DOCKERFILE: Dockerfile
@@ -5,7 +8,7 @@
     IMAGE_NAMES: $CI_PROJECT_NAME:$CI_COMMIT_BRANCH $CI_PROJECT_NAME:$CI_COMMIT_SHORT_SHA $CI_PROJECT_NAME:latest
     EXTRA_BUILD_ARGS: ""
   image:
-    name: ghcr.io/kaniko-build/dist/chainguard-dev-kaniko/executor:v1.25.1-debug
+    name: $GHCR_REGISTRY/kaniko-build/dist/chainguard-dev-kaniko/executor:v1.25.1-debug
     entrypoint: [""]
   script:
     # CA
@@ -36,10 +39,10 @@
     - for I in $IMAGE_NAMES; do export ALL_DESTINATIONS="$ALL_DESTINATIONS --destination $IMAGE_REPOSITORY/$(echo $I | tr \/ '-')"; done
     - mkdir -p /kaniko/.docker
     - echo "$DOCKER_AUTH" > /kaniko/.docker/config.json
-    - /kaniko/executor 
+    - /kaniko/executor
       --single-snapshot
-      --context="$CI_PROJECT_DIR/$WORKING_DIR" 
-      --dockerfile="$CI_PROJECT_DIR/$DOCKERFILE" 
+      --context="$CI_PROJECT_DIR/$WORKING_DIR"
+      --dockerfile="$CI_PROJECT_DIR/$DOCKERFILE"
       $BUILD_ARGS $EXTRA_BUILD_ARGS $EXTRA_KANIKO_ARGS
       $ALL_DESTINATIONS
 
@@ -50,7 +53,7 @@
     IMAGE_NAME: $IMAGE_NAMES
     EXTRA_BUILD_ARGS: ""
   image:
-    name: ghcr.io/kaniko-build/dist/chainguard-dev-kaniko/executor:v1.25.1-debug
+    name: $GHCR_REGISTRY/kaniko-build/dist/chainguard-dev-kaniko/executor:v1.25.1-debug
     entrypoint: [""]
   script:
     # CA

--- a/mirror.yml
+++ b/mirror.yml
@@ -1,7 +1,9 @@
 # yaml-language-server: $schema=https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/assets/javascripts/editor/schema/ci.json
+variables:
+  GHCR_REGISTRY: ghcr.io
 
 .repo_pull_sync:
-  image: ghcr.io/cloud-pi-native/git-sync:1
+  image: $GHCR_REGISTRY/cloud-pi-native/git-sync:1
   variables:
     CI_SKIP:
       value: "false"
@@ -28,30 +30,30 @@
     - export GIT_OUTPUT_PASSWORD=`vault kv get ${EXTRA_VAULT_ARGS} -field=GIT_OUTPUT_PASSWORD ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/${PROJECT_NAME}-mirror`
     - export GIT_OUTPUT_URL=`vault kv get ${EXTRA_VAULT_ARGS} -field=GIT_OUTPUT_URL ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/${PROJECT_NAME}-mirror`
     - |
-        GIT_OPTIONS=""
-        if [ "${CI_SKIP}" = 'true' ]; then
-          GIT_OPTIONS="${GIT_OPTIONS} -o ci.skip"
-        fi
-        if [ "${PUSH_TAGS}" = 'true' ]; then
-          GIT_OPTIONS="${GIT_OPTIONS} --tags"
-        fi
+      GIT_OPTIONS=""
+      if [ "${CI_SKIP}" = 'true' ]; then
+        GIT_OPTIONS="${GIT_OPTIONS} -o ci.skip"
+      fi
+      if [ "${PUSH_TAGS}" = 'true' ]; then
+        GIT_OPTIONS="${GIT_OPTIONS} --tags"
+      fi
     - |
-        if [ "${SYNC_ALL}" = 'true' ]; then
-          git clone --mirror ${EXTRA_GIT_ARGS} "https://${GIT_INPUT_USER}:${GIT_INPUT_PASSWORD}@${GIT_INPUT_URL}" ./clonerepo
-        else
-          git clone ${EXTRA_GIT_ARGS} "https://${GIT_INPUT_USER}:${GIT_INPUT_PASSWORD}@${GIT_INPUT_URL}" ./clonerepo;
-        fi
+      if [ "${SYNC_ALL}" = 'true' ]; then
+        git clone --mirror ${EXTRA_GIT_ARGS} "https://${GIT_INPUT_USER}:${GIT_INPUT_PASSWORD}@${GIT_INPUT_URL}" ./clonerepo
+      else
+        git clone ${EXTRA_GIT_ARGS} "https://${GIT_INPUT_USER}:${GIT_INPUT_PASSWORD}@${GIT_INPUT_URL}" ./clonerepo;
+      fi
     - cd ./clonerepo
-    - | 
-        if [ "${SYNC_ALL}" = 'true' ]; then 
-          printf "syncing all branches\n"
-          git -c http.postBuffer=262144000 ${EXTRA_GIT_ARGS} push --force --prune \
-            "http://${GIT_OUTPUT_USER}:${GIT_OUTPUT_PASSWORD}@${GIT_OUTPUT_URL}" \
-            "refs/heads/*:refs/heads/*" \
-            "refs/tags/*:refs/tags/*" \
-            ${GIT_OPTIONS}
-        else
-          printf "syncing branch ${GIT_BRANCH_DEPLOY}\n"
-          git checkout ${GIT_BRANCH_DEPLOY} && \
-          git ${EXTRA_GIT_ARGS} push --force --prune "http://${GIT_OUTPUT_USER}:${GIT_OUTPUT_PASSWORD}@${GIT_OUTPUT_URL}" ${GIT_BRANCH_DEPLOY} ${GIT_OPTIONS}
-        fi
+    - |
+      if [ "${SYNC_ALL}" = 'true' ]; then
+        printf "syncing all branches\n"
+        git -c http.postBuffer=262144000 ${EXTRA_GIT_ARGS} push --force --prune \
+          "http://${GIT_OUTPUT_USER}:${GIT_OUTPUT_PASSWORD}@${GIT_OUTPUT_URL}" \
+          "refs/heads/*:refs/heads/*" \
+          "refs/tags/*:refs/tags/*" \
+          ${GIT_OPTIONS}
+      else
+        printf "syncing branch ${GIT_BRANCH_DEPLOY}\n"
+        git checkout ${GIT_BRANCH_DEPLOY} && \
+        git ${EXTRA_GIT_ARGS} push --force --prune "http://${GIT_OUTPUT_USER}:${GIT_OUTPUT_PASSWORD}@${GIT_OUTPUT_URL}" ${GIT_BRANCH_DEPLOY} ${GIT_OPTIONS}
+      fi

--- a/sonar-ci.yml
+++ b/sonar-ci.yml
@@ -1,12 +1,13 @@
 variables:
-  SONAR_SCANNER_EXTRA_ARGS: ''
+  DOCKER_REGISTRY: docker.io
+  SONAR_SCANNER_EXTRA_ARGS: ""
   SONAR_PROJECT_KEY: ${PROJECT_KEY}
   SONAR_PROJECT_VERSION: ${CI_COMMIT_REF_NAME}
-  SONAR_WAIT_QUALITY_GATE: 'true'
+  SONAR_WAIT_QUALITY_GATE: "true"
 
 .sonar:sonar-scanner:
-  image: 
-    name: docker.io/sonarsource/sonar-scanner-cli:11
+  image:
+    name: $DOCKER_REGISTRY/sonarsource/sonar-scanner-cli:11
     entrypoint: [""]
   variables:
     SONAR_USER_HOME: "${CI_PROJECT_DIR}/.sonar"

--- a/vault-ci.yml
+++ b/vault-ci.yml
@@ -1,6 +1,9 @@
+variables:
+  DOCKER_REGISTRY: docker.io
+
 .vault:read_secret:
   image:
-    name: docker.io/hashicorp/vault:1.17.1
+    name: $DOCKER_REGISTRY/hashicorp/vault:1.17.1
   id_tokens:
     VAULT_ID_TOKEN:
       aud: $VAULT_SERVER_URL
@@ -17,25 +20,33 @@
       DOCKER_AUTH=`vault kv get $EXTRA_VAULT_ARGS -field=DOCKER_CONFIG ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/REGISTRY/rw-robot`
       REGISTRY_HOST=`vault kv get $EXTRA_VAULT_ARGS -field=HOST ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/REGISTRY/rw-robot`
       SONAR_TOKEN=`vault kv get $EXTRA_VAULT_ARGS -field=SONAR_TOKEN ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/SONAR`
-      NEXUS_USERNAME=`vault kv get $EXTRA_VAULT_ARGS -field=NEXUS_USERNAME ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/NEXUS`
-      NEXUS_PASSWORD=`vault kv get $EXTRA_VAULT_ARGS -field=NEXUS_PASSWORD ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/NEXUS`
+
+      # Check if NEXUS path exists in Vault
+      if vault kv get $EXTRA_VAULT_ARGS ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/NEXUS >/dev/null 2>&1; then
+        NEXUS_USERNAME=`vault kv get $EXTRA_VAULT_ARGS -field=NEXUS_USERNAME ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/NEXUS`
+        NEXUS_PASSWORD=`vault kv get $EXTRA_VAULT_ARGS -field=NEXUS_PASSWORD ${VAULT_KV}/${CI_PROJECT_NAMESPACE}/NEXUS`
+        if [[ -n "$NEXUS_PASSWORD" ]]; then
+          NEXUS_CREDS_B64=`echo -n "$NEXUS_USERNAME:$NEXUS_PASSWORD" | base64`
+        fi
+      else
+        echo "NEXUS path does not exist in Vault. Skipping Nexus-related values."
+      fi
+
       PROJECT_PATH=`echo "$CI_PROJECT_NAMESPACE" | awk -F '/' '{print $(NF)}'`
       IMAGE_REPOSITORY="${REGISTRY_HOST}/${PROJECT_PATH}"
-      if [[ -n $NEXUS_PASSWORD ]]; then
-        NEXUS_CREDS_B64=`echo -n "$NEXUS_USERNAME:$NEXUS_PASSWORD" | base64`
-      fi  
+
       cat <<EOF > vault.env
       REGISTRY_HOST=$REGISTRY_HOST
       IMAGE_REPOSITORY=$IMAGE_REPOSITORY
       PROJECT_PATH=$PROJECT_PATH
       DOCKER_AUTH=$DOCKER_AUTH
       SONAR_TOKEN=$SONAR_TOKEN
-      NEXUS_USERNAME=$NEXUS_USERNAME
-      NEXUS_PASSWORD=$NEXUS_PASSWORD
-      NEXUS_CREDS_B64=$NEXUS_CREDS_B64
+      NEXUS_USERNAME=${NEXUS_USERNAME:-}
+      NEXUS_PASSWORD=${NEXUS_PASSWORD:-}
+      NEXUS_CREDS_B64=${NEXUS_CREDS_B64:-}
       EOF
   artifacts:
     access: none
     reports:
       dotenv: vault.env
-    expire_in: 60 min 
+    expire_in: 60 min


### PR DESCRIPTION
## Quel est le comportement actuel ?
Les URLs des registries (ex: `ghcr.io`, `docker.io`) sont **hard codés** dans chaque fichier CI (`kaniko-ci.yml`, `mirror.yml`, `sonar-ci.yml`, `vault-ci.yml`).
La récupération des identifiants Nexus dans `vault-ci.yml` est **non conditionnelle** : si le chemin `/NEXUS` n'existe pas dans Vault, le pipeline échoue.

## Quel est le nouveau comportement ?
- **Surcharge des registries** :
  Les variables globales (`GHCR_REGISTRY`, `DOCKER_REGISTRY`) sont définies en haut de chaque fichier CI et **utilisées pour surcharger** les URLs des registries.
  Cela permet de centraliser la configuration et d'utiliser un autre registry sans introduire de *breaking changes* (les valeurs par défaut restent identiques).

- **Gestion conditionnelle de Nexus** :
  Dans `vault-ci.yml`, la récupération des identifiants Nexus est désormais **conditionnelle** :
  - Vérification de l'existence du chemin `/NEXUS` dans Vault avant toute tentative de récupération.
  - Si le chemin n'existe pas, les variables Nexus sont laissées vides (avec des valeurs par défaut via `${VAR:-}`).
  - Cela permet de **désactiver le plugin Nexus** dans la console sans impacter le pipeline.

- **Nettoyage mineur** :
  Suppression des espaces superflus (formatage automatique).

## Cette PR introduit-elle un breaking change ?
Non :
- Les valeurs par défaut des registries (`ghcr.io`, `docker.io`) restent inchangées.
- La gestion conditionnelle de Nexus est **rétrocompatible** : si le chemin `/NEXUS` existe, le comportement est identique à avant.

## Autres informations
Aujourd'hui la console offre la possibilité de désactiver le "plugin" Nexus, mais le job vault-ci ne passe pas en l'absence du chemin `/NEXUS` dans l'espace Vault du projet qui est créé uniquement avec ce plugin.